### PR TITLE
Add Data Source Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 <p align='center'>Bring CAP-NZ (Common Alerting Protocol - New Zealand) data from RSS and Atom feeds</p>
 
+## Data Source
+
+| Alerting authority | CAP feed | Content |
+|---|---|---|
+| GNS Science | https://api.geonet.org.nz/cap/1.2/GPA1.0/feed/atom1.0/quake | Earthquake |
+| MetService | https://alerts.metservice.com/cap/rss | Severe weather |
+| NEMA, CDEM Groups, Ministry of Health, New Zealand Police, Ministry for Primary Industries, Fire and Emergency New Zealand | https://alerthub.civildefence.govt.nz/rss/pwp or https://alerthub.civildefence.govt.nz/atom/pwp | Emergency Mobile Alert |
+
 ## Deployment
 
 Deployment into the CloudTAK environment for ETL tasks is done via automatic releases to the TAK.NZ AWS environment.


### PR DESCRIPTION
## Summary
Added a Data Source section to the README with comprehensive information about CAP feed sources.

## Changes
- Added Data Source section with table format
- Listed all three alerting authorities and their feed URLs
- Documented content types for each feed source

## Details
The table includes:
- **GNS Science**: Earthquake data from atom feed
- **MetService**: Severe weather alerts from RSS feed  
- **NEMA/CDEM Groups**: Emergency mobile alerts with both RSS and atom feed options
