### PR TITLE
Add Category-Specific Icons for Health and Fire CAP Alerts

### DIFF
--- a/task.ts
+++ b/task.ts
@@ -186,7 +186,13 @@ export default class Task extends ETL {
         return Task.EVENT_MAP[eventCode] || eventCode || 'Unknown';
     }
 
-    private getEventIcon(eventType: string): string {
+    private getEventIcon(eventType: string, category?: string): string {
+        if (category === 'Health') {
+            return `${Task.ICON_PREFIX}Incidents/INC.60.GHS08.HealthHazard.png`;
+        }
+        if (category === 'Fire') {
+            return `${Task.ICON_PREFIX}Incidents/INC.35.Fire.png`;
+        }
         const iconFile = Task.ICON_MAP[eventType] || Task.DEFAULT_ICON;
         return `${Task.ICON_PREFIX}${iconFile}`;
     }
@@ -676,7 +682,7 @@ export default class Task extends ETL {
                                         time: new Date(alert.sent).toISOString(),
                                         start: alert.info.onset ? new Date(alert.info.onset).toISOString() : new Date(alert.sent).toISOString(),
                                         stale: alert.info.expires ? new Date(alert.info.expires).toISOString() : undefined,
-                                        icon: this.getEventIcon(alert.info.event),
+                                        icon: this.getEventIcon(alert.info.event, alert.info.category),
                                         metadata: {
                                             ...polygonFeature.properties.metadata,
                                             isCenter: true
@@ -742,7 +748,7 @@ export default class Task extends ETL {
                         time: new Date(alert.sent).toISOString(),
                         start: alert.info.onset ? new Date(alert.info.onset).toISOString() : new Date(alert.sent).toISOString(),
                         stale: alert.info.expires ? new Date(alert.info.expires).toISOString() : undefined,
-                        icon: this.getEventIcon(alert.info.event),
+                        icon: this.getEventIcon(alert.info.event, alert.info.category),
                         metadata: {
                             sender: alert.sender,
                             sent: alert.sent,


### PR DESCRIPTION
## Summary
This PR enhances the CAP-NZ ETL to use more appropriate icons for Health and Fire category alerts by prioritizing category-based icon selection over event-based mapping.

## Changes
- **Enhanced icon selection logic**: Modified `getEventIcon()` method to accept an optional `category` parameter
- **Health alerts**: Now use `Incidents/INC.60.GHS08.HealthHazard.png` icon for better visual identification
- **Fire alerts**: Now use `Incidents/INC.35.Fire.png` icon for consistent fire-related visualization
- **Backward compatibility**: Maintains existing event-based icon mapping for all other categories

## Impact
- Improves visual clarity for health-related alerts (e.g., boil water notices, public health warnings)
- Provides consistent fire iconography across all fire-related incidents
- Enhances user experience in CloudTAK interface with more intuitive alert categorization

## Testing
Tested with sample CAP alerts including health category boil water notices to verify correct icon assignment.
