### PR TITLE
Update @tak-ps/etl to v9.22.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
             "license": "AGPL-3.0-only",
             "dependencies": {
                 "@sinclair/typebox": "^0.34.0",
-                "@tak-ps/etl": "^9.0.0",
+                "@tak-ps/etl": "^9.22.0",
                 "fast-xml-parser": "^4.3.2",
                 "object-hash": "^3.0.0"
             },
@@ -1061,6 +1061,13 @@
                 "node": ">= 18"
             }
         },
+        "node_modules/@orbat-mapper/convert-symbology": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@orbat-mapper/convert-symbology/-/convert-symbology-1.0.2.tgz",
+            "integrity": "sha512-FpnPXS16/C+ay7FVPLhTkRH2NmREKxhJ+pifqcW9NpsbORH94S14qU8Eyl2ofMP7upxQYNvw2qpTok5I3P4QKw==",
+            "license": "MIT",
+            "peer": true
+        },
         "node_modules/@pkgjs/parseargs": {
             "version": "0.11.0",
             "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -1720,9 +1727,9 @@
             }
         },
         "node_modules/@tak-ps/etl": {
-            "version": "9.18.0",
-            "resolved": "https://registry.npmjs.org/@tak-ps/etl/-/etl-9.18.0.tgz",
-            "integrity": "sha512-lSfF1d39Y++mzf1w70WT1NS9NzwUOCG0RHU46Hvn/6+cGA0p4QK040ot1EfZ2LTakOe+/Rv1BT7ymwlZzd1vuQ==",
+            "version": "9.24.0",
+            "resolved": "https://registry.npmjs.org/@tak-ps/etl/-/etl-9.24.0.tgz",
+            "integrity": "sha512-6SjpNJcbhYiRrgyfBjbCO1pxZGnlGbSoXjkxwAcdSDV7VvTOR4oYiMlCo0/EUZbL3fHTyYviadve6WJlrWHNFQ==",
             "license": "ISC",
             "dependencies": {
                 "@aws-sdk/client-secrets-manager": "^3.828.0",
@@ -1742,17 +1749,18 @@
                 "node": ">= 22"
             },
             "peerDependencies": {
-                "@tak-ps/node-cot": "^13.2.0"
+                "@tak-ps/node-cot": "^14.1.0"
             }
         },
         "node_modules/@tak-ps/node-cot": {
-            "version": "13.6.0",
-            "resolved": "https://registry.npmjs.org/@tak-ps/node-cot/-/node-cot-13.6.0.tgz",
-            "integrity": "sha512-YGnzKwfe57t7wS1hftQH1p4DMpVm7pjGwUeJTJ3FG/SIn7CPgrauK8aa68X4NPvvgST3dnmWMbtbf2RHlKe+DQ==",
+            "version": "14.12.0",
+            "resolved": "https://registry.npmjs.org/@tak-ps/node-cot/-/node-cot-14.12.0.tgz",
+            "integrity": "sha512-JHlBiBVXuyBbySDFgFPjpvUEzzfuxNgmC8qh87wDkK0B8A0tFm1NviASkZF3/ucb2L63w6gI9kg8vWdiEFAeiA==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
                 "@openaddresses/batch-error": "^2.4.0",
+                "@orbat-mapper/convert-symbology": "^1.0.2",
                 "@sinclair/typebox": "^0.34.0",
                 "@turf/destination": "^7.2.0",
                 "@turf/ellipse": "^7.0.0",
@@ -1771,7 +1779,7 @@
                 "node-stream-zip": "^1.15.0",
                 "protobufjs": "^7.3.0",
                 "rimraf": "^6.0.0",
-                "uuid": "^11.1.0",
+                "uuid": "^13.0.0",
                 "xml-js": "^1.6.11"
             },
             "engines": {
@@ -1779,9 +1787,9 @@
             }
         },
         "node_modules/@tak-ps/node-cot/node_modules/uuid": {
-            "version": "11.1.0",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-            "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+            "version": "13.0.0",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
+            "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
             "funding": [
                 "https://github.com/sponsors/broofa",
                 "https://github.com/sponsors/ctavan"
@@ -1789,7 +1797,7 @@
             "license": "MIT",
             "peer": true,
             "bin": {
-                "uuid": "dist/esm/bin/uuid"
+                "uuid": "dist-node/bin/uuid"
             }
         },
         "node_modules/@tak-ps/serverless-http": {
@@ -2194,9 +2202,9 @@
             }
         },
         "node_modules/@types/archiver": {
-            "version": "6.0.3",
-            "resolved": "https://registry.npmjs.org/@types/archiver/-/archiver-6.0.3.tgz",
-            "integrity": "sha512-a6wUll6k3zX6qs5KlxIggs1P1JcYJaTCx2gnlr+f0S1yd2DoaEwoIK10HmBaLnZwWneBz+JBm0dwcZu0zECBcQ==",
+            "version": "6.0.4",
+            "resolved": "https://registry.npmjs.org/@types/archiver/-/archiver-6.0.4.tgz",
+            "integrity": "sha512-ULdQpARQ3sz9WH4nb98mJDYA0ft2A8C4f4fovvUcFwINa1cgGjY36JCAYuP5YypRq4mco1lJp1/7jEMS2oR0Hg==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
@@ -2925,11 +2933,19 @@
             "peer": true
         },
         "node_modules/b4a": {
-            "version": "1.6.7",
-            "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.7.tgz",
-            "integrity": "sha512-OnAYlL5b7LEkALw87fUVafQw5rVR9RjwGd4KUwNQ6DrrNmaVaUCgLipfVlzrPQ4tWOR9P0IXGNOx50jYCCdSJg==",
+            "version": "1.7.3",
+            "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.7.3.tgz",
+            "integrity": "sha512-5Q2mfq2WfGuFp3uS//0s6baOJLMoVduPYVeNmDYxu5OUA1/cBfvr2RIS7vi62LdNj/urk1hfmj867I3qt6uZ7Q==",
             "license": "Apache-2.0",
-            "peer": true
+            "peer": true,
+            "peerDependencies": {
+                "react-native-b4a": "*"
+            },
+            "peerDependenciesMeta": {
+                "react-native-b4a": {
+                    "optional": true
+                }
+            }
         },
         "node_modules/balanced-match": {
             "version": "1.0.2",
@@ -2938,12 +2954,19 @@
             "license": "MIT"
         },
         "node_modules/bare-events": {
-            "version": "2.6.0",
-            "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.6.0.tgz",
-            "integrity": "sha512-EKZ5BTXYExaNqi3I3f9RtEsaI/xBSGjE0XZCZilPzFAV/goswFHuPd9jEZlPIZ/iNZJwDSao9qRiScySz7MbQg==",
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.1.tgz",
+            "integrity": "sha512-oxSAxTS1hRfnyit2CL5QpAOS5ixfBjj6ex3yTNvXyY/kE719jQ/IjuESJBK2w5v4wwQRAHGseVJXx9QBYOtFGQ==",
             "license": "Apache-2.0",
-            "optional": true,
-            "peer": true
+            "peer": true,
+            "peerDependencies": {
+                "bare-abort-controller": "*"
+            },
+            "peerDependenciesMeta": {
+                "bare-abort-controller": {
+                    "optional": true
+                }
+            }
         },
         "node_modules/base64-js": {
             "version": "1.5.1",
@@ -3141,9 +3164,9 @@
             }
         },
         "node_modules/color": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/color/-/color-5.0.0.tgz",
-            "integrity": "sha512-16BlyiuyLq3MLxpRWyOTiWsO3ii/eLQLJUQXBSNcxMBBSnyt1ee9YUdaozQp03ifwm5woztEZGDbk9RGVuCsdw==",
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/color/-/color-5.0.2.tgz",
+            "integrity": "sha512-e2hz5BzbUPcYlIRHo8ieAhYgoajrJr+hWoceg6E345TPsATMUKqDgzt8fSXZJJbxfpiPzkWyphz8yn8At7q3fA==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
@@ -3155,9 +3178,9 @@
             }
         },
         "node_modules/color-convert": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.0.tgz",
-            "integrity": "sha512-TVoqAq8ZDIpK5lsQY874DDnu65CSsc9vzq0wLpNQ6UMBq81GSZocVazPiBbYGzngzBOIRahpkTzCLVe2at4MfA==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.2.tgz",
+            "integrity": "sha512-UNqkvCDXstVck3kdowtOTWROIJQwafjOfXSmddoDrXo4cewMKmusCeF22Q24zvjR8nwWib/3S/dfyzPItPEiJg==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
@@ -3168,9 +3191,9 @@
             }
         },
         "node_modules/color-name": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.0.0.tgz",
-            "integrity": "sha512-SbtvAMWvASO5TE2QP07jHBMXKafgdZz8Vrsrn96fiL+O92/FN/PLARzUW5sKt013fjAprK2d2iCn2hk2Xb5oow==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.0.2.tgz",
+            "integrity": "sha512-9vEt7gE16EW7Eu7pvZnR0abW9z6ufzhXxGXZEVU9IqPdlsUiMwJeJfRtq0zePUmnbHGT9zajca7mX8zgoayo4A==",
             "license": "MIT",
             "peer": true,
             "engines": {
@@ -3178,9 +3201,9 @@
             }
         },
         "node_modules/color-string": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/color-string/-/color-string-2.0.1.tgz",
-            "integrity": "sha512-5z9FbYTZPAo8iKsNEqRNv+OlpBbDcoE+SY9GjLfDUHEfcNNV7tS9eSAlFHEaub/r5tBL9LtskAeq1l9SaoZ5tQ==",
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/color-string/-/color-string-2.1.2.tgz",
+            "integrity": "sha512-RxmjYxbWemV9gKu4zPgiZagUxbH3RQpEIO77XoSSX0ivgABDZ+h8Zuash/EMFLTI4N9QgFPOJ6JQpPZKFxa+dA==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
@@ -3656,6 +3679,16 @@
             "peer": true,
             "engines": {
                 "node": ">=0.8.x"
+            }
+        },
+        "node_modules/events-universal": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+            "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "bare-events": "^2.7.0"
             }
         },
         "node_modules/express": {
@@ -4313,9 +4346,9 @@
             "license": "MIT"
         },
         "node_modules/json-diff-ts": {
-            "version": "4.8.1",
-            "resolved": "https://registry.npmjs.org/json-diff-ts/-/json-diff-ts-4.8.1.tgz",
-            "integrity": "sha512-Bjs+7bgxkolosAL1n/29XJXCXByAVMdhARkRk32HpJ2IuCvZ/KpqT79ljlYZZRlcN6JE0ygNxRPR+mEMPQBshw==",
+            "version": "4.8.2",
+            "resolved": "https://registry.npmjs.org/json-diff-ts/-/json-diff-ts-4.8.2.tgz",
+            "integrity": "sha512-7LgOTnfK5XnBs0o0AtHTkry5QGZT7cSlAgu5GtiomUeoHqOavAUDcONNm/bCe4Lapt0AHnaidD5iSE+ItvxKkA==",
             "license": "MIT",
             "peer": true
         },
@@ -4595,9 +4628,9 @@
             }
         },
         "node_modules/milsymbol": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/milsymbol/-/milsymbol-3.0.2.tgz",
-            "integrity": "sha512-iYHfum8GCVRpmaRVsRDbw5ZOPY0td3Ltl5+w63caxA2iecS0o1alDnUFUSKaf+Tn8LmA0eUEcSglWR0sLgIDQw==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/milsymbol/-/milsymbol-3.0.3.tgz",
+            "integrity": "sha512-Fy/32WaGwitTTaILyLVxsh/pHsiBVKKieC0Ply/LRWLrOGivOB96WjGXSRWlWmXLI+wfoO6/vDfjwR7tyP47fA==",
             "license": "MIT",
             "peer": true
         },
@@ -4993,9 +5026,9 @@
             "peer": true
         },
         "node_modules/protobufjs": {
-            "version": "7.5.3",
-            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.3.tgz",
-            "integrity": "sha512-sildjKwVqOI2kmFDiXQ6aEB0fjYTafpEvIBs8tOR8qI4spuL9OPROLVu2qZqi/xgCfsHIwVqlaF8JBjWFHnKbw==",
+            "version": "7.5.4",
+            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
+            "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
             "hasInstallScript": true,
             "license": "BSD-3-Clause",
             "peer": true,
@@ -5450,17 +5483,15 @@
             }
         },
         "node_modules/streamx": {
-            "version": "2.22.1",
-            "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.22.1.tgz",
-            "integrity": "sha512-znKXEBxfatz2GBNK02kRnCXjV+AA4kjZIUxeWSr3UGirZMJfTE9uiwKHobnbgxWyL/JWro8tTq+vOqAK1/qbSA==",
+            "version": "2.23.0",
+            "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.23.0.tgz",
+            "integrity": "sha512-kn+e44esVfn2Fa/O0CPFcex27fjIL6MkVae0Mm6q+E6f0hWv578YCERbv+4m02cjxvDsPKLnmxral/rR6lBMAg==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
+                "events-universal": "^1.0.0",
                 "fast-fifo": "^1.3.2",
                 "text-decoder": "^1.1.0"
-            },
-            "optionalDependencies": {
-                "bare-events": "^2.2.0"
             }
         },
         "node_modules/string_decoder": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     },
     "dependencies": {
         "@sinclair/typebox": "^0.34.0",
-        "@tak-ps/etl": "^9.0.0",
+        "@tak-ps/etl": "^9.22.0",
         "object-hash": "^3.0.0",
         "fast-xml-parser": "^4.3.2"
     }

--- a/task.ts
+++ b/task.ts
@@ -1,6 +1,6 @@
 
-import { Static, Type, TSchema } from '@sinclair/typebox';
-import ETL, { Event, SchemaType, handler as internal, local, DataFlowType, InvocationType, InputFeatureCollection } from '@tak-ps/etl';
+import { Type, TSchema } from '@sinclair/typebox';
+import ETL, { Event, SchemaType, handler as internal, local, DataFlowType, InvocationType } from '@tak-ps/etl';
 import { XMLParser } from 'fast-xml-parser';
 import { createHash } from 'crypto';
 
@@ -556,9 +556,14 @@ export default class Task extends ETL {
         const alertUrls = await this.parseFeed(feedText);
         console.log(`Found ${alertUrls.length} CAP alerts in feed`);
 
-        const fc: Static<typeof InputFeatureCollection> = {
-            type: 'FeatureCollection',
-            features: []
+        const fc = {
+            type: 'FeatureCollection' as const,
+            features: [] as Array<{
+                id: string;
+                type: 'Feature';
+                properties: Record<string, unknown>;
+                geometry: SupportedGeometry;
+            }>
         };
 
         // Fetch and process each CAP alert


### PR DESCRIPTION
## Summary
Updates the `@tak-ps/etl` dependency to version 9.22.0 to resolve schema errors with ETL Layer Get operations and ensures compatibility with the latest ETL framework.

## Changes Made
- **Dependency Update**: Upgraded `@tak-ps/etl` from `^9.0.0` to `^9.22.0`
- **Import Fixes**: Removed `InputFeatureCollection` import as it's no longer exported in the new version
- **Type Safety**: Replaced `Static<typeof InputFeatureCollection>` with proper TypeScript types
- **Code Quality**: Fixed linting issues by removing unused imports and replacing `any` types

## Breaking Changes
The `InputFeatureCollection` type is no longer available as a named export from `@tak-ps/etl`. This has been replaced with inline type definitions that maintain the same functionality.

## Testing
- ✅ TypeScript compilation passes
- ✅ ESLint passes without errors
- ✅ No runtime functionality changes

## Impact
This update resolves the schema error that was causing ETL Layer Get operations to fail and ensures the ETL remains compatible with the CloudTAK environment.