### PR TITLE
Fix Event Icon Mapping for CAP Alerts

### DIFF
--- a/task.ts
+++ b/task.ts
@@ -193,7 +193,44 @@ export default class Task extends ETL {
         if (category === 'Fire') {
             return `${Task.ICON_PREFIX}Incidents/INC.35.Fire.png`;
         }
-        const iconFile = Task.ICON_MAP[eventType] || Task.DEFAULT_ICON;
+        
+        // Handle empty or undefined eventType
+        if (!eventType || typeof eventType !== 'string') {
+            const iconFile = Task.DEFAULT_ICON;
+            return `${Task.ICON_PREFIX}${iconFile}`;
+        }
+        
+        const normalized = eventType.toLowerCase().replace(/[\s-]+/g, '');
+        
+        // Pattern matching for event types
+        const patterns: Record<string, string> = {
+            'thunderstorm|thunder': 'thunderstorm',
+            'flashflood': 'flashFlood',
+            'heavyrain|rainfall': 'rainfall',
+            'strongwind|galewind|stormwind': 'wind',
+            'winterstorm': 'winterStorm',
+            'stormsurge': 'stormSurge',
+            'tropicalcyclone': 'tropCyclone',
+            'tropicalstorm': 'tropStorm',
+            'earthquake': 'earthquake',
+            'tsunami': 'tsunami',
+            'tornado': 'tornado',
+            'flood': 'flood',
+            'snow|snowfall': 'snow',
+            'hail': 'hail',
+            'marine': 'marine',
+            'waterspout': 'waterspout'
+        };
+        
+        for (const [pattern, key] of Object.entries(patterns)) {
+            if (pattern.split('|').some(p => normalized.includes(p))) {
+                const iconFile = Task.ICON_MAP[key] || Task.DEFAULT_ICON;
+                return `${Task.ICON_PREFIX}${iconFile}`;
+            }
+        }
+        
+        // Try direct lookup with normalized event
+        const iconFile = Task.ICON_MAP[normalized] || Task.ICON_MAP[eventType.toLowerCase()] || Task.DEFAULT_ICON;
         return `${Task.ICON_PREFIX}${iconFile}`;
     }
 


### PR DESCRIPTION
## Problem
Severe thunderstorm warnings were displaying the generic `a-f-X-i` icon instead of the proper thunderstorm icon (`NH.06.ElectricalStorm`). The issue affected events with case sensitivity, compound names, or variations in naming.

## Root Cause
The `getEventIcon` method used exact string matching which failed when:
- Event types had different capitalization ("Thunderstorm" vs "thunderstorm")
- Event names contained spaces ("Flash Flood", "Winter Storm")
- Event variations weren't accounted for ("Heavy Rain" vs "Rainfall")

## Solution
Implemented a robust pattern matching system that:

1. **Normalizes input** - Converts to lowercase and removes spaces/hyphens
2. **Pattern matching** - Uses flexible patterns to catch variations:
   - `thunderstorm|thunder` → catches "Thunderstorm", "Severe Thunderstorm Warning"
   - `flashflood` → catches "Flash Flood"
   - `heavyrain|rainfall` → catches "Heavy Rain", "Rainfall"
3. **Null protection** - Handles empty/undefined event types gracefully
4. **Fallback chain** - Multiple fallback options ensure icons are always assigned

## Testing
- ✅ Thunderstorm warnings now display electrical storm icon
- ✅ Thunderstorm watches continue to work correctly
- ✅ Other event types (flood, wind, snow, etc.) remain unaffected
- ✅ Handles edge cases with missing/invalid event data

## Impact
- Fixes visual identification of severe weather events in CloudTAK
- Improves user experience for emergency responders
- Makes the system more resilient to CAP feed variations
- Extensible pattern system for future event types
