### PR TITLE
Fix: Expired CAP alerts persisting on map

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -149,45 +149,45 @@
             }
         },
         "node_modules/@aws-sdk/client-secrets-manager": {
-            "version": "3.1009.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.1009.0.tgz",
-            "integrity": "sha512-8CaFVjwOotZAsWKEXXPe23wwb1hqJWmy1os8WYCcN90h5VGdje47HeLgh66VDUJDTV2iWx1QeTBtwihioUB90w==",
+            "version": "3.1012.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.1012.0.tgz",
+            "integrity": "sha512-sSxBnb16C0iHkQv09FOgwICKQGYsUxiwBNBwuRlyUzBNJg+E8Uyw/Pc01f08TfhiIZOKOtZV9hvd7SyzkmGmGA==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
-                "@aws-sdk/core": "^3.973.20",
-                "@aws-sdk/credential-provider-node": "^3.972.21",
+                "@aws-sdk/core": "^3.973.21",
+                "@aws-sdk/credential-provider-node": "^3.972.22",
                 "@aws-sdk/middleware-host-header": "^3.972.8",
                 "@aws-sdk/middleware-logger": "^3.972.8",
                 "@aws-sdk/middleware-recursion-detection": "^3.972.8",
-                "@aws-sdk/middleware-user-agent": "^3.972.21",
+                "@aws-sdk/middleware-user-agent": "^3.972.22",
                 "@aws-sdk/region-config-resolver": "^3.972.8",
                 "@aws-sdk/types": "^3.973.6",
                 "@aws-sdk/util-endpoints": "^3.996.5",
                 "@aws-sdk/util-user-agent-browser": "^3.972.8",
-                "@aws-sdk/util-user-agent-node": "^3.973.7",
+                "@aws-sdk/util-user-agent-node": "^3.973.8",
                 "@smithy/config-resolver": "^4.4.11",
-                "@smithy/core": "^3.23.11",
+                "@smithy/core": "^3.23.12",
                 "@smithy/fetch-http-handler": "^5.3.15",
                 "@smithy/hash-node": "^4.2.12",
                 "@smithy/invalid-dependency": "^4.2.12",
                 "@smithy/middleware-content-length": "^4.2.12",
-                "@smithy/middleware-endpoint": "^4.4.25",
-                "@smithy/middleware-retry": "^4.4.42",
-                "@smithy/middleware-serde": "^4.2.14",
+                "@smithy/middleware-endpoint": "^4.4.26",
+                "@smithy/middleware-retry": "^4.4.43",
+                "@smithy/middleware-serde": "^4.2.15",
                 "@smithy/middleware-stack": "^4.2.12",
                 "@smithy/node-config-provider": "^4.3.12",
-                "@smithy/node-http-handler": "^4.4.16",
+                "@smithy/node-http-handler": "^4.5.0",
                 "@smithy/protocol-http": "^5.3.12",
-                "@smithy/smithy-client": "^4.12.5",
+                "@smithy/smithy-client": "^4.12.6",
                 "@smithy/types": "^4.13.1",
                 "@smithy/url-parser": "^4.2.12",
                 "@smithy/util-base64": "^4.3.2",
                 "@smithy/util-body-length-browser": "^4.2.2",
                 "@smithy/util-body-length-node": "^4.2.3",
-                "@smithy/util-defaults-mode-browser": "^4.3.41",
-                "@smithy/util-defaults-mode-node": "^4.2.44",
+                "@smithy/util-defaults-mode-browser": "^4.3.42",
+                "@smithy/util-defaults-mode-node": "^4.2.45",
                 "@smithy/util-endpoints": "^3.3.3",
                 "@smithy/util-middleware": "^4.2.12",
                 "@smithy/util-retry": "^4.2.12",
@@ -199,19 +199,19 @@
             }
         },
         "node_modules/@aws-sdk/core": {
-            "version": "3.973.20",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.20.tgz",
-            "integrity": "sha512-i3GuX+lowD892F3IuJf8o6AbyDupMTdyTxQrCJGcn71ni5hTZ82L4nQhcdumxZ7XPJRJJVHS/CR3uYOIIs0PVA==",
+            "version": "3.973.21",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.21.tgz",
+            "integrity": "sha512-OTUcDX9Yfz/FLKbHjiMaP9D4Hs44lYJzN7zBcrK2nDmBt0Wr8D6nYt12QoBkZsW0nVMFsTIGaZCrsU9zCcIMXQ==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-sdk/types": "^3.973.6",
-                "@aws-sdk/xml-builder": "^3.972.11",
-                "@smithy/core": "^3.23.11",
+                "@aws-sdk/xml-builder": "^3.972.12",
+                "@smithy/core": "^3.23.12",
                 "@smithy/node-config-provider": "^4.3.12",
                 "@smithy/property-provider": "^4.2.12",
                 "@smithy/protocol-http": "^5.3.12",
                 "@smithy/signature-v4": "^5.3.12",
-                "@smithy/smithy-client": "^4.12.5",
+                "@smithy/smithy-client": "^4.12.6",
                 "@smithy/types": "^4.13.1",
                 "@smithy/util-base64": "^4.3.2",
                 "@smithy/util-middleware": "^4.2.12",
@@ -223,12 +223,12 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-env": {
-            "version": "3.972.18",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.18.tgz",
-            "integrity": "sha512-X0B8AlQY507i5DwjLByeU2Af4ARsl9Vr84koDcXCbAkplmU+1xBFWxEPrWRAoh56waBne/yJqEloSwvRf4x6XA==",
+            "version": "3.972.19",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.19.tgz",
+            "integrity": "sha512-33NpkQtmnsjLr9QdZvL3w8bjy+WoBJ+jY8JwuzxIq38rDNi1kwpBWW7Yjh+8bMlksd+ZAWW0fH4S/6OeoAdU5A==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "^3.973.20",
+                "@aws-sdk/core": "^3.973.21",
                 "@aws-sdk/types": "^3.973.6",
                 "@smithy/property-provider": "^4.2.12",
                 "@smithy/types": "^4.13.1",
@@ -239,20 +239,20 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-http": {
-            "version": "3.972.20",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.20.tgz",
-            "integrity": "sha512-ey9Lelj001+oOfrbKmS6R2CJAiXX7QKY4Vj9VJv6L2eE6/VjD8DocHIoYqztTm70xDLR4E1jYPTKfIui+eRNDA==",
+            "version": "3.972.21",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.21.tgz",
+            "integrity": "sha512-xFke7yjbON4unNOG0TApQwz+o1LH5VhVLgWlUuiLRWNDyBfeHIFje2ck8qHybvJ8Fkm5m3SsN+pvHtVo6PGWlQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "^3.973.20",
+                "@aws-sdk/core": "^3.973.21",
                 "@aws-sdk/types": "^3.973.6",
                 "@smithy/fetch-http-handler": "^5.3.15",
-                "@smithy/node-http-handler": "^4.4.16",
+                "@smithy/node-http-handler": "^4.5.0",
                 "@smithy/property-provider": "^4.2.12",
                 "@smithy/protocol-http": "^5.3.12",
-                "@smithy/smithy-client": "^4.12.5",
+                "@smithy/smithy-client": "^4.12.6",
                 "@smithy/types": "^4.13.1",
-                "@smithy/util-stream": "^4.5.19",
+                "@smithy/util-stream": "^4.5.20",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -260,19 +260,19 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-ini": {
-            "version": "3.972.20",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.20.tgz",
-            "integrity": "sha512-5flXSnKHMloObNF+9N0cupKegnH1Z37cdVlpETVgx8/rAhCe+VNlkcZH3HDg2SDn9bI765S+rhNPXGDJJPfbtA==",
+            "version": "3.972.21",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.21.tgz",
+            "integrity": "sha512-fmJN7KhB7CoG65w9fC2LVOd2wZbR2d1yJIpZNe2J5CeDPu7nUHSmavuJAeGEoE3OL5UIBVPNhmK/fV/NQrs3Hw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "^3.973.20",
-                "@aws-sdk/credential-provider-env": "^3.972.18",
-                "@aws-sdk/credential-provider-http": "^3.972.20",
-                "@aws-sdk/credential-provider-login": "^3.972.20",
-                "@aws-sdk/credential-provider-process": "^3.972.18",
-                "@aws-sdk/credential-provider-sso": "^3.972.20",
-                "@aws-sdk/credential-provider-web-identity": "^3.972.20",
-                "@aws-sdk/nested-clients": "^3.996.10",
+                "@aws-sdk/core": "^3.973.21",
+                "@aws-sdk/credential-provider-env": "^3.972.19",
+                "@aws-sdk/credential-provider-http": "^3.972.21",
+                "@aws-sdk/credential-provider-login": "^3.972.21",
+                "@aws-sdk/credential-provider-process": "^3.972.19",
+                "@aws-sdk/credential-provider-sso": "^3.972.21",
+                "@aws-sdk/credential-provider-web-identity": "^3.972.21",
+                "@aws-sdk/nested-clients": "^3.996.11",
                 "@aws-sdk/types": "^3.973.6",
                 "@smithy/credential-provider-imds": "^4.2.12",
                 "@smithy/property-provider": "^4.2.12",
@@ -285,13 +285,13 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-login": {
-            "version": "3.972.20",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.20.tgz",
-            "integrity": "sha512-gEWo54nfqp2jABMu6HNsjVC4hDLpg9HC8IKSJnp0kqWtxIJYHTmiLSsIfI4ScQjxEwpB+jOOH8dOLax1+hy/Hw==",
+            "version": "3.972.21",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.21.tgz",
+            "integrity": "sha512-ENU+YCiuQocQjfIf9bPxZ+ZY0wIBkl3SMH22optBQwy8UFpSfonHynXzGT27xQxer4cYTNOpwDqbfo57BusbpQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "^3.973.20",
-                "@aws-sdk/nested-clients": "^3.996.10",
+                "@aws-sdk/core": "^3.973.21",
+                "@aws-sdk/nested-clients": "^3.996.11",
                 "@aws-sdk/types": "^3.973.6",
                 "@smithy/property-provider": "^4.2.12",
                 "@smithy/protocol-http": "^5.3.12",
@@ -304,17 +304,17 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-node": {
-            "version": "3.972.21",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.21.tgz",
-            "integrity": "sha512-hah8if3/B/Q+LBYN5FukyQ1Mym6PLPDsBOBsIgNEYD6wLyZg0UmUF/OKIVC3nX9XH8TfTPuITK+7N/jenVACWA==",
+            "version": "3.972.22",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.22.tgz",
+            "integrity": "sha512-VE6i8nkmrRyhKut7nnfCWRbdDf+CfyRr8ixSwdaPDguYlgvkAO2pHu9oK11XzbSuatB0io1ozI/vpYhelXn8Pg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/credential-provider-env": "^3.972.18",
-                "@aws-sdk/credential-provider-http": "^3.972.20",
-                "@aws-sdk/credential-provider-ini": "^3.972.20",
-                "@aws-sdk/credential-provider-process": "^3.972.18",
-                "@aws-sdk/credential-provider-sso": "^3.972.20",
-                "@aws-sdk/credential-provider-web-identity": "^3.972.20",
+                "@aws-sdk/credential-provider-env": "^3.972.19",
+                "@aws-sdk/credential-provider-http": "^3.972.21",
+                "@aws-sdk/credential-provider-ini": "^3.972.21",
+                "@aws-sdk/credential-provider-process": "^3.972.19",
+                "@aws-sdk/credential-provider-sso": "^3.972.21",
+                "@aws-sdk/credential-provider-web-identity": "^3.972.21",
                 "@aws-sdk/types": "^3.973.6",
                 "@smithy/credential-provider-imds": "^4.2.12",
                 "@smithy/property-provider": "^4.2.12",
@@ -327,12 +327,12 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-process": {
-            "version": "3.972.18",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.18.tgz",
-            "integrity": "sha512-Tpl7SRaPoOLT32jbTWchPsn52hYYgJ0kpiFgnwk8pxTANQdUymVSZkzFvv1+oOgZm1CrbQUP9MBeoMZ9IzLZjA==",
+            "version": "3.972.19",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.19.tgz",
+            "integrity": "sha512-hjj5bFo4kf5/WzAMjDEFByVOMbq5gZiagIpJexf7Kp9nIDaGzhCphMsx03NCA8s9zUJzHlD1lXazd7MS+e03Lg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "^3.973.20",
+                "@aws-sdk/core": "^3.973.21",
                 "@aws-sdk/types": "^3.973.6",
                 "@smithy/property-provider": "^4.2.12",
                 "@smithy/shared-ini-file-loader": "^4.4.7",
@@ -344,14 +344,14 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-sso": {
-            "version": "3.972.20",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.20.tgz",
-            "integrity": "sha512-p+R+PYR5Z7Gjqf/6pvbCnzEHcqPCpLzR7Yf127HjJ6EAb4hUcD+qsNRnuww1sB/RmSeCLxyay8FMyqREw4p1RA==",
+            "version": "3.972.21",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.21.tgz",
+            "integrity": "sha512-9jWRCuMZpZKlqCZ46bvievqdfswsyB2yPAr9rOiN+FxaGgf8jrR5iYDqJgscvk1jrbAxiK4cIjHv3XjIAWAhzQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "^3.973.20",
-                "@aws-sdk/nested-clients": "^3.996.10",
-                "@aws-sdk/token-providers": "3.1009.0",
+                "@aws-sdk/core": "^3.973.21",
+                "@aws-sdk/nested-clients": "^3.996.11",
+                "@aws-sdk/token-providers": "3.1012.0",
                 "@aws-sdk/types": "^3.973.6",
                 "@smithy/property-provider": "^4.2.12",
                 "@smithy/shared-ini-file-loader": "^4.4.7",
@@ -363,13 +363,13 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-web-identity": {
-            "version": "3.972.20",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.20.tgz",
-            "integrity": "sha512-rWCmh8o7QY4CsUj63qopzMzkDq/yPpkrpb+CnjBEFSOg/02T/we7sSTVg4QsDiVS9uwZ8VyONhq98qt+pIh3KA==",
+            "version": "3.972.21",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.21.tgz",
+            "integrity": "sha512-ShWQO/cQVZ+j3zUDK7Kj+m7grPzQCVA2iaZdJ+hJTGvVH5lR32Ip/rgZZ+zBdH6D6wczP9Upa4NMXoqJdGpK1g==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "^3.973.20",
-                "@aws-sdk/nested-clients": "^3.996.10",
+                "@aws-sdk/core": "^3.973.21",
+                "@aws-sdk/nested-clients": "^3.996.11",
                 "@aws-sdk/types": "^3.973.6",
                 "@smithy/property-provider": "^4.2.12",
                 "@smithy/shared-ini-file-loader": "^4.4.7",
@@ -426,15 +426,15 @@
             }
         },
         "node_modules/@aws-sdk/middleware-user-agent": {
-            "version": "3.972.21",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.21.tgz",
-            "integrity": "sha512-62XRl1GDYPpkt7cx1AX1SPy9wgNE9Iw/NPuurJu4lmhCWS7sGKO+kS53TQ8eRmIxy3skmvNInnk0ZbWrU5Dpyg==",
+            "version": "3.972.22",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.22.tgz",
+            "integrity": "sha512-pZPNGWZVQvgUIO/P9PXZNz7ciq9mLYb/wQEurg3phKTa3DiBIunIRcgA0eBNwmog6S3oy0KR1bv4EJ4ld9A5sQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "^3.973.20",
+                "@aws-sdk/core": "^3.973.21",
                 "@aws-sdk/types": "^3.973.6",
                 "@aws-sdk/util-endpoints": "^3.996.5",
-                "@smithy/core": "^3.23.11",
+                "@smithy/core": "^3.23.12",
                 "@smithy/protocol-http": "^5.3.12",
                 "@smithy/types": "^4.13.1",
                 "@smithy/util-retry": "^4.2.12",
@@ -445,44 +445,44 @@
             }
         },
         "node_modules/@aws-sdk/nested-clients": {
-            "version": "3.996.10",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.996.10.tgz",
-            "integrity": "sha512-SlDol5Z+C7Ivnc2rKGqiqfSUmUZzY1qHfVs9myt/nxVwswgfpjdKahyTzLTx802Zfq0NFRs7AejwKzzzl5Co2w==",
+            "version": "3.996.11",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.996.11.tgz",
+            "integrity": "sha512-i7SwoSR4JB/79JoGDUACnFUQOZwXGLWNX35lIb1Pq72nUGlVV+RFZp+BLa8S+mog2pbXU9+6Kc5YwGiMi5bKhQ==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
-                "@aws-sdk/core": "^3.973.20",
+                "@aws-sdk/core": "^3.973.21",
                 "@aws-sdk/middleware-host-header": "^3.972.8",
                 "@aws-sdk/middleware-logger": "^3.972.8",
                 "@aws-sdk/middleware-recursion-detection": "^3.972.8",
-                "@aws-sdk/middleware-user-agent": "^3.972.21",
+                "@aws-sdk/middleware-user-agent": "^3.972.22",
                 "@aws-sdk/region-config-resolver": "^3.972.8",
                 "@aws-sdk/types": "^3.973.6",
                 "@aws-sdk/util-endpoints": "^3.996.5",
                 "@aws-sdk/util-user-agent-browser": "^3.972.8",
-                "@aws-sdk/util-user-agent-node": "^3.973.7",
+                "@aws-sdk/util-user-agent-node": "^3.973.8",
                 "@smithy/config-resolver": "^4.4.11",
-                "@smithy/core": "^3.23.11",
+                "@smithy/core": "^3.23.12",
                 "@smithy/fetch-http-handler": "^5.3.15",
                 "@smithy/hash-node": "^4.2.12",
                 "@smithy/invalid-dependency": "^4.2.12",
                 "@smithy/middleware-content-length": "^4.2.12",
-                "@smithy/middleware-endpoint": "^4.4.25",
-                "@smithy/middleware-retry": "^4.4.42",
-                "@smithy/middleware-serde": "^4.2.14",
+                "@smithy/middleware-endpoint": "^4.4.26",
+                "@smithy/middleware-retry": "^4.4.43",
+                "@smithy/middleware-serde": "^4.2.15",
                 "@smithy/middleware-stack": "^4.2.12",
                 "@smithy/node-config-provider": "^4.3.12",
-                "@smithy/node-http-handler": "^4.4.16",
+                "@smithy/node-http-handler": "^4.5.0",
                 "@smithy/protocol-http": "^5.3.12",
-                "@smithy/smithy-client": "^4.12.5",
+                "@smithy/smithy-client": "^4.12.6",
                 "@smithy/types": "^4.13.1",
                 "@smithy/url-parser": "^4.2.12",
                 "@smithy/util-base64": "^4.3.2",
                 "@smithy/util-body-length-browser": "^4.2.2",
                 "@smithy/util-body-length-node": "^4.2.3",
-                "@smithy/util-defaults-mode-browser": "^4.3.41",
-                "@smithy/util-defaults-mode-node": "^4.2.44",
+                "@smithy/util-defaults-mode-browser": "^4.3.42",
+                "@smithy/util-defaults-mode-node": "^4.2.45",
                 "@smithy/util-endpoints": "^3.3.3",
                 "@smithy/util-middleware": "^4.2.12",
                 "@smithy/util-retry": "^4.2.12",
@@ -510,13 +510,13 @@
             }
         },
         "node_modules/@aws-sdk/token-providers": {
-            "version": "3.1009.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1009.0.tgz",
-            "integrity": "sha512-KCPLuTqN9u0Rr38Arln78fRG9KXpzsPWmof+PZzfAHMMQq2QED6YjQrkrfiH7PDefLWEposY1o4/eGwrmKA4JA==",
+            "version": "3.1012.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1012.0.tgz",
+            "integrity": "sha512-vzKwy020zjuiF4WTJzejx5nYcXJnRhHpb6i3lyZHIwfFwXG1yX4bzBVNMWYWF+bz1i2Pp2VhJbPyzpqj4VuJXQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "^3.973.20",
-                "@aws-sdk/nested-clients": "^3.996.10",
+                "@aws-sdk/core": "^3.973.21",
+                "@aws-sdk/nested-clients": "^3.996.11",
                 "@aws-sdk/types": "^3.973.6",
                 "@smithy/property-provider": "^4.2.12",
                 "@smithy/shared-ini-file-loader": "^4.4.7",
@@ -581,12 +581,12 @@
             }
         },
         "node_modules/@aws-sdk/util-user-agent-node": {
-            "version": "3.973.7",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.7.tgz",
-            "integrity": "sha512-Hz6EZMUAEzqUd7e+vZ9LE7mn+5gMbxltXy18v+YSFY+9LBJz15wkNZvw5JqfX3z0FS9n3bgUtz3L5rAsfh4YlA==",
+            "version": "3.973.8",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.8.tgz",
+            "integrity": "sha512-Kvb96TafGPLYo4Z2GRCzQTne77epXgiZEo0DDXwavzkWmgDV/1XD1tMA766gzRcHHFUraWsE+4T8DKtPTZUxgQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/middleware-user-agent": "^3.972.21",
+                "@aws-sdk/middleware-user-agent": "^3.972.22",
                 "@aws-sdk/types": "^3.973.6",
                 "@smithy/node-config-provider": "^4.3.12",
                 "@smithy/types": "^4.13.1",
@@ -606,36 +606,17 @@
             }
         },
         "node_modules/@aws-sdk/xml-builder": {
-            "version": "3.972.11",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.11.tgz",
-            "integrity": "sha512-iitV/gZKQMvY9d7ovmyFnFuTHbBAtrmLnvaSb/3X8vOKyevwtpmEtyc8AdhVWZe0pI/1GsHxlEvQeOePFzy7KQ==",
+            "version": "3.972.13",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.13.tgz",
+            "integrity": "sha512-I/+BMxM4WE/6xL0tyV7tAUDOAXmyw/va1oGr/eSly43HmLUcD1G+v96vEKAA8VoLcZ03ZQo/PWzjmN9zQErqPQ==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/types": "^4.13.1",
-                "fast-xml-parser": "5.4.1",
+                "fast-xml-parser": "5.5.6",
                 "tslib": "^2.6.2"
             },
             "engines": {
                 "node": ">=20.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/xml-builder/node_modules/fast-xml-parser": {
-            "version": "5.4.1",
-            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.4.1.tgz",
-            "integrity": "sha512-BQ30U1mKkvXQXXkAGcuyUA/GA26oEB7NzOtsxCDtyu62sjGw5QraKFhx2Em3WQNjPw9PG6MQ9yuIIgkSDfGu5A==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/NaturalIntelligence"
-                }
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "fast-xml-builder": "^1.0.0",
-                "strnum": "^2.1.2"
-            },
-            "bin": {
-                "fxparser": "src/cli/cli.js"
             }
         },
         "node_modules/@aws/lambda-invoke-store": {
@@ -966,8 +947,9 @@
             "version": "0.23.3",
             "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.3.tgz",
             "integrity": "sha512-j+eEWmB6YYLwcNOdlwQ6L2OsptI/LO6lNBuLIqe5R7RetD658HLoF+Mn7LzYmAWWNNzdC6cqP+L6r8ujeYXWLw==",
-            "extraneous": true,
             "license": "Apache-2.0",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "@eslint/object-schema": "^3.0.3",
                 "debug": "^4.3.1",
@@ -981,8 +963,9 @@
             "version": "0.5.3",
             "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.3.tgz",
             "integrity": "sha512-lzGN0onllOZCGroKJmRwY6QcEHxbjBw1gwB8SgRSqK8YbbtEXMvKynsXc3553ckIEBxsbMBU7oOZXKIPGZNeZw==",
-            "extraneous": true,
             "license": "Apache-2.0",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "@eslint/core": "^1.1.1"
             },
@@ -994,8 +977,9 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.1.1.tgz",
             "integrity": "sha512-QUPblTtE51/7/Zhfv8BDwO0qkkzQL7P/aWWbqcf4xWLEYn1oKjdO0gglQBB4GAsu7u6wjijbCmzsUTy6mnk6oQ==",
-            "extraneous": true,
             "license": "Apache-2.0",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "@types/json-schema": "^7.0.15"
             },
@@ -1027,8 +1011,9 @@
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.3.tgz",
             "integrity": "sha512-iM869Pugn9Nsxbh/YHRqYiqd23AmIbxJOcpUMOuWCVNdoQJ5ZtwL6h3t0bcZzJUlC3Dq9jCFCESBZnX0GTv7iQ==",
-            "extraneous": true,
             "license": "Apache-2.0",
+            "optional": true,
+            "peer": true,
             "engines": {
                 "node": "^20.19.0 || ^22.13.0 || >=24"
             }
@@ -1037,8 +1022,9 @@
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.6.1.tgz",
             "integrity": "sha512-iH1B076HoAshH1mLpHMgwdGeTs0CYwL0SPMkGuSebZrwBp16v415e9NZXg2jtrqPVQjf6IANe2Vtlr5KswtcZQ==",
-            "extraneous": true,
             "license": "Apache-2.0",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "@eslint/core": "^1.1.1",
                 "levn": "^0.4.1"
@@ -1051,8 +1037,9 @@
             "version": "4.0.4",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
             "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-            "extraneous": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "engines": {
                 "node": "18 || 20 || >=22"
             }
@@ -1061,8 +1048,9 @@
             "version": "5.0.4",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
             "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
-            "extraneous": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "balanced-match": "^4.0.2"
             },
@@ -1074,8 +1062,9 @@
             "version": "10.0.3",
             "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.0.3.tgz",
             "integrity": "sha512-COV33RzXZkqhG9P2rZCFl9ZmJ7WL+gQSCRzE7RhkbclbQPtLAWReL7ysA0Sh4c8Im2U9ynybdR56PV0XcKvqaQ==",
-            "extraneous": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.8.0",
                 "@eslint-community/regexpp": "^4.12.2",
@@ -1130,8 +1119,9 @@
             "version": "9.1.2",
             "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
             "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
-            "extraneous": true,
             "license": "BSD-2-Clause",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "@types/esrecurse": "^4.3.1",
                 "@types/estree": "^1.0.8",
@@ -1149,8 +1139,9 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
             "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
-            "extraneous": true,
             "license": "Apache-2.0",
+            "optional": true,
+            "peer": true,
             "engines": {
                 "node": "^20.19.0 || ^22.13.0 || >=24"
             },
@@ -1162,8 +1153,9 @@
             "version": "6.14.0",
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
             "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
-            "extraneous": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "fast-json-stable-stringify": "^2.0.0",
@@ -1179,8 +1171,9 @@
             "version": "11.2.0",
             "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
             "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
-            "extraneous": true,
             "license": "BSD-2-Clause",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "acorn": "^8.16.0",
                 "acorn-jsx": "^5.3.2",
@@ -1197,15 +1190,17 @@
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
             "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-            "extraneous": true,
-            "license": "MIT"
+            "license": "MIT",
+            "optional": true,
+            "peer": true
         },
         "node_modules/@openaddresses/batch-schema/node_modules/minimatch": {
             "version": "10.2.4",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
             "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
-            "extraneous": true,
             "license": "BlueOak-1.0.0",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "brace-expansion": "^5.0.2"
             },
@@ -1345,9 +1340,9 @@
             }
         },
         "node_modules/@smithy/core": {
-            "version": "3.23.11",
-            "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.11.tgz",
-            "integrity": "sha512-952rGf7hBRnhUIaeLp6q4MptKW8sPFe5VvkoZ5qIzFAtx6c/QZ/54FS3yootsyUSf9gJX/NBqEBNdNR7jMIlpQ==",
+            "version": "3.23.12",
+            "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.12.tgz",
+            "integrity": "sha512-o9VycsYNtgC+Dy3I0yrwCqv9CWicDnke0L7EVOrZtJpjb2t0EjaEofmMrYc0T1Kn3yk32zm6cspxF9u9Bj7e5w==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/protocol-http": "^5.3.12",
@@ -1356,7 +1351,7 @@
                 "@smithy/util-base64": "^4.3.2",
                 "@smithy/util-body-length-browser": "^4.2.2",
                 "@smithy/util-middleware": "^4.2.12",
-                "@smithy/util-stream": "^4.5.19",
+                "@smithy/util-stream": "^4.5.20",
                 "@smithy/util-utf8": "^4.2.2",
                 "@smithy/uuid": "^1.1.2",
                 "tslib": "^2.6.2"
@@ -1452,13 +1447,13 @@
             }
         },
         "node_modules/@smithy/middleware-endpoint": {
-            "version": "4.4.25",
-            "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.25.tgz",
-            "integrity": "sha512-dqjLwZs2eBxIUG6Qtw8/YZ4DvzHGIf0DA18wrgtfP6a50UIO7e2nY0FPdcbv5tVJKqWCCU5BmGMOUwT7Puan+A==",
+            "version": "4.4.26",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.26.tgz",
+            "integrity": "sha512-8Qfikvd2GVKSm8S6IbjfwFlRY9VlMrj0Dp4vTwAuhqbX7NhJKE5DQc2bnfJIcY0B+2YKMDBWfvexbSZeejDgeg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/core": "^3.23.11",
-                "@smithy/middleware-serde": "^4.2.14",
+                "@smithy/core": "^3.23.12",
+                "@smithy/middleware-serde": "^4.2.15",
                 "@smithy/node-config-provider": "^4.3.12",
                 "@smithy/shared-ini-file-loader": "^4.4.7",
                 "@smithy/types": "^4.13.1",
@@ -1471,15 +1466,15 @@
             }
         },
         "node_modules/@smithy/middleware-retry": {
-            "version": "4.4.42",
-            "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.42.tgz",
-            "integrity": "sha512-vbwyqHRIpIZutNXZpLAozakzamcINaRCpEy1MYmK6xBeW3xN+TyPRA123GjXnuxZIjc9848MRRCugVMTXxC4Eg==",
+            "version": "4.4.43",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.43.tgz",
+            "integrity": "sha512-ZwsifBdyuNHrFGmbc7bAfP2b54+kt9J2rhFd18ilQGAB+GDiP4SrawqyExbB7v455QVR7Psyhb2kjULvBPIhvA==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/node-config-provider": "^4.3.12",
                 "@smithy/protocol-http": "^5.3.12",
                 "@smithy/service-error-classification": "^4.2.12",
-                "@smithy/smithy-client": "^4.12.5",
+                "@smithy/smithy-client": "^4.12.6",
                 "@smithy/types": "^4.13.1",
                 "@smithy/util-middleware": "^4.2.12",
                 "@smithy/util-retry": "^4.2.12",
@@ -1491,12 +1486,12 @@
             }
         },
         "node_modules/@smithy/middleware-serde": {
-            "version": "4.2.14",
-            "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.14.tgz",
-            "integrity": "sha512-+CcaLoLa5apzSRtloOyG7lQvkUw2ZDml3hRh4QiG9WyEPfW5Ke/3tPOPiPjUneuT59Tpn8+c3RVaUvvkkwqZwg==",
+            "version": "4.2.15",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.15.tgz",
+            "integrity": "sha512-ExYhcltZSli0pgAKOpQQe1DLFBLryeZ22605y/YS+mQpdNWekum9Ujb/jMKfJKgjtz1AZldtwA/wCYuKJgjjlg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/core": "^3.23.11",
+                "@smithy/core": "^3.23.12",
                 "@smithy/protocol-http": "^5.3.12",
                 "@smithy/types": "^4.13.1",
                 "tslib": "^2.6.2"
@@ -1534,9 +1529,9 @@
             }
         },
         "node_modules/@smithy/node-http-handler": {
-            "version": "4.4.16",
-            "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.16.tgz",
-            "integrity": "sha512-ULC8UCS/HivdCB3jhi+kLFYe4B5gxH2gi9vHBfEIiRrT2jfKiZNiETJSlzRtE6B26XbBHjPtc8iZKSNqMol9bw==",
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.5.0.tgz",
+            "integrity": "sha512-Rnq9vQWiR1+/I6NZZMNzJHV6pZYyEHt2ZnuV3MG8z2NNenC4i/8Kzttz7CjZiHSmsN5frhXhg17z3Zqjjhmz1A==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/abort-controller": "^4.2.12",
@@ -1647,17 +1642,17 @@
             }
         },
         "node_modules/@smithy/smithy-client": {
-            "version": "4.12.5",
-            "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.5.tgz",
-            "integrity": "sha512-UqwYawyqSr/aog8mnLnfbPurS0gi4G7IYDcD28cUIBhsvWs1+rQcL2IwkUQ+QZ7dibaoRzhNF99fAQ9AUcO00w==",
+            "version": "4.12.6",
+            "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.6.tgz",
+            "integrity": "sha512-aib3f0jiMsJ6+cvDnXipBsGDL7ztknYSVqJs1FdN9P+u9tr/VzOR7iygSh6EUOdaBeMCMSh3N0VdyYsG4o91DQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/core": "^3.23.11",
-                "@smithy/middleware-endpoint": "^4.4.25",
+                "@smithy/core": "^3.23.12",
+                "@smithy/middleware-endpoint": "^4.4.26",
                 "@smithy/middleware-stack": "^4.2.12",
                 "@smithy/protocol-http": "^5.3.12",
                 "@smithy/types": "^4.13.1",
-                "@smithy/util-stream": "^4.5.19",
+                "@smithy/util-stream": "^4.5.20",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -1754,13 +1749,13 @@
             }
         },
         "node_modules/@smithy/util-defaults-mode-browser": {
-            "version": "4.3.41",
-            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.41.tgz",
-            "integrity": "sha512-M1w1Ux0rSVvBOxIIiqbxvZvhnjQ+VUjJrugtORE90BbadSTH+jsQL279KRL3Hv0w69rE7EuYkV/4Lepz/NBW9g==",
+            "version": "4.3.42",
+            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.42.tgz",
+            "integrity": "sha512-0vjwmcvkWAUtikXnWIUOyV6IFHTEeQUYh3JUZcDgcszF+hD/StAsQ3rCZNZEPHgI9kVNcbnyc8P2CBHnwgmcwg==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/property-provider": "^4.2.12",
-                "@smithy/smithy-client": "^4.12.5",
+                "@smithy/smithy-client": "^4.12.6",
                 "@smithy/types": "^4.13.1",
                 "tslib": "^2.6.2"
             },
@@ -1769,16 +1764,16 @@
             }
         },
         "node_modules/@smithy/util-defaults-mode-node": {
-            "version": "4.2.44",
-            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.44.tgz",
-            "integrity": "sha512-YPze3/lD1KmWuZsl9JlfhcgGLX7AXhSoaCDtiPntUjNW5/YY0lOHjkcgxyE9x/h5vvS1fzDifMGjzqnNlNiqOQ==",
+            "version": "4.2.45",
+            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.45.tgz",
+            "integrity": "sha512-q5dOqqfTgUcLe38TAGiFn9srToKj2YCHJ34QGOLzM+xYLLA+qRZv7N+33kl1MERVusue36ZHnlNaNEvY/PzSrw==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/config-resolver": "^4.4.11",
                 "@smithy/credential-provider-imds": "^4.2.12",
                 "@smithy/node-config-provider": "^4.3.12",
                 "@smithy/property-provider": "^4.2.12",
-                "@smithy/smithy-client": "^4.12.5",
+                "@smithy/smithy-client": "^4.12.6",
                 "@smithy/types": "^4.13.1",
                 "tslib": "^2.6.2"
             },
@@ -1840,13 +1835,13 @@
             }
         },
         "node_modules/@smithy/util-stream": {
-            "version": "4.5.19",
-            "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.19.tgz",
-            "integrity": "sha512-v4sa+3xTweL1CLO2UP0p7tvIMH/Rq1X4KKOxd568mpe6LSLMQCnDHs4uv7m3ukpl3HvcN2JH6jiCS0SNRXKP/w==",
+            "version": "4.5.20",
+            "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.20.tgz",
+            "integrity": "sha512-4yXLm5n/B5SRBR2p8cZ90Sbv4zL4NKsgxdzCzp/83cXw2KxLEumt5p+GAVyRNZgQOSrzXn9ARpO0lUe8XSlSDw==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/fetch-http-handler": "^5.3.15",
-                "@smithy/node-http-handler": "^4.4.16",
+                "@smithy/node-http-handler": "^4.5.0",
                 "@smithy/types": "^4.13.1",
                 "@smithy/util-base64": "^4.3.2",
                 "@smithy/util-buffer-from": "^4.2.2",
@@ -1922,9 +1917,9 @@
             }
         },
         "node_modules/@tak-ps/node-cot": {
-            "version": "14.29.0",
-            "resolved": "https://registry.npmjs.org/@tak-ps/node-cot/-/node-cot-14.29.0.tgz",
-            "integrity": "sha512-3+OQtg7tlsIvHRLq6zQTJhtm9EPS00WfR8s/ZWJ95wFOB+T0o5rXM9VzMaz2720Lk+GdZTzyMnsZZkKHQ8dXaw==",
+            "version": "14.30.1",
+            "resolved": "https://registry.npmjs.org/@tak-ps/node-cot/-/node-cot-14.30.1.tgz",
+            "integrity": "sha512-1cHjOha+6qTBajyfMqojN42kkAEjPRSeJbS7GTMYbrT/mgtGIqFHwBXi/Bau1RS1bBYbJu1Vp9RfwTgwEGCJQQ==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
@@ -2399,8 +2394,9 @@
             "version": "4.3.1",
             "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
             "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
-            "extraneous": true,
-            "license": "MIT"
+            "license": "MIT",
+            "optional": true,
+            "peer": true
         },
         "node_modules/@types/estree": {
             "version": "1.0.8",
@@ -2541,17 +2537,17 @@
             }
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "8.57.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.57.0.tgz",
-            "integrity": "sha512-qeu4rTHR3/IaFORbD16gmjq9+rEs9fGKdX0kF6BKSfi+gCuG3RCKLlSBYzn/bGsY9Tj7KE/DAQStbp8AHJGHEQ==",
+            "version": "8.57.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.57.1.tgz",
+            "integrity": "sha512-Gn3aqnvNl4NGc6x3/Bqk1AOn0thyTU9bqDRhiRnUWezgvr2OnhYCWCgC8zXXRVqBsIL1pSDt7T9nJUe0oM0kDQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/regexpp": "^4.12.2",
-                "@typescript-eslint/scope-manager": "8.57.0",
-                "@typescript-eslint/type-utils": "8.57.0",
-                "@typescript-eslint/utils": "8.57.0",
-                "@typescript-eslint/visitor-keys": "8.57.0",
+                "@typescript-eslint/scope-manager": "8.57.1",
+                "@typescript-eslint/type-utils": "8.57.1",
+                "@typescript-eslint/utils": "8.57.1",
+                "@typescript-eslint/visitor-keys": "8.57.1",
                 "ignore": "^7.0.5",
                 "natural-compare": "^1.4.0",
                 "ts-api-utils": "^2.4.0"
@@ -2564,7 +2560,7 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "@typescript-eslint/parser": "^8.57.0",
+                "@typescript-eslint/parser": "^8.57.1",
                 "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
                 "typescript": ">=4.8.4 <6.0.0"
             }
@@ -2580,16 +2576,16 @@
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "8.57.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.57.0.tgz",
-            "integrity": "sha512-XZzOmihLIr8AD1b9hL9ccNMzEMWt/dE2u7NyTY9jJG6YNiNthaD5XtUHVF2uCXZ15ng+z2hT3MVuxnUYhq6k1g==",
+            "version": "8.57.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.57.1.tgz",
+            "integrity": "sha512-k4eNDan0EIMTT/dUKc/g+rsJ6wcHYhNPdY19VoX/EOtaAG8DLtKCykhrUnuHPYvinn5jhAPgD2Qw9hXBwrahsw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/scope-manager": "8.57.0",
-                "@typescript-eslint/types": "8.57.0",
-                "@typescript-eslint/typescript-estree": "8.57.0",
-                "@typescript-eslint/visitor-keys": "8.57.0",
+                "@typescript-eslint/scope-manager": "8.57.1",
+                "@typescript-eslint/types": "8.57.1",
+                "@typescript-eslint/typescript-estree": "8.57.1",
+                "@typescript-eslint/visitor-keys": "8.57.1",
                 "debug": "^4.4.3"
             },
             "engines": {
@@ -2605,14 +2601,14 @@
             }
         },
         "node_modules/@typescript-eslint/project-service": {
-            "version": "8.57.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.57.0.tgz",
-            "integrity": "sha512-pR+dK0BlxCLxtWfaKQWtYr7MhKmzqZxuii+ZjuFlZlIGRZm22HnXFqa2eY+90MUz8/i80YJmzFGDUsi8dMOV5w==",
+            "version": "8.57.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.57.1.tgz",
+            "integrity": "sha512-vx1F37BRO1OftsYlmG9xay1TqnjNVlqALymwWVuYTdo18XuKxtBpCj1QlzNIEHlvlB27osvXFWptYiEWsVdYsg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/tsconfig-utils": "^8.57.0",
-                "@typescript-eslint/types": "^8.57.0",
+                "@typescript-eslint/tsconfig-utils": "^8.57.1",
+                "@typescript-eslint/types": "^8.57.1",
                 "debug": "^4.4.3"
             },
             "engines": {
@@ -2627,14 +2623,14 @@
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "8.57.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.57.0.tgz",
-            "integrity": "sha512-nvExQqAHF01lUM66MskSaZulpPL5pgy5hI5RfrxviLgzZVffB5yYzw27uK/ft8QnKXI2X0LBrHJFr1TaZtAibw==",
+            "version": "8.57.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.57.1.tgz",
+            "integrity": "sha512-hs/QcpCwlwT2L5S+3fT6gp0PabyGk4Q0Rv2doJXA0435/OpnSR3VRgvrp8Xdoc3UAYSg9cyUjTeFXZEPg/3OKg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.57.0",
-                "@typescript-eslint/visitor-keys": "8.57.0"
+                "@typescript-eslint/types": "8.57.1",
+                "@typescript-eslint/visitor-keys": "8.57.1"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2645,9 +2641,9 @@
             }
         },
         "node_modules/@typescript-eslint/tsconfig-utils": {
-            "version": "8.57.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.57.0.tgz",
-            "integrity": "sha512-LtXRihc5ytjJIQEH+xqjB0+YgsV4/tW35XKX3GTZHpWtcC8SPkT/d4tqdf1cKtesryHm2bgp6l555NYcT2NLvA==",
+            "version": "8.57.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.57.1.tgz",
+            "integrity": "sha512-0lgOZB8cl19fHO4eI46YUx2EceQqhgkPSuCGLlGi79L2jwYY1cxeYc1Nae8Aw1xjgW3PKVDLlr3YJ6Bxx8HkWg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -2662,15 +2658,15 @@
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "8.57.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.57.0.tgz",
-            "integrity": "sha512-yjgh7gmDcJ1+TcEg8x3uWQmn8ifvSupnPfjP21twPKrDP/pTHlEQgmKcitzF/rzPSmv7QjJ90vRpN4U+zoUjwQ==",
+            "version": "8.57.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.57.1.tgz",
+            "integrity": "sha512-+Bwwm0ScukFdyoJsh2u6pp4S9ktegF98pYUU0hkphOOqdMB+1sNQhIz8y5E9+4pOioZijrkfNO/HUJVAFFfPKA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.57.0",
-                "@typescript-eslint/typescript-estree": "8.57.0",
-                "@typescript-eslint/utils": "8.57.0",
+                "@typescript-eslint/types": "8.57.1",
+                "@typescript-eslint/typescript-estree": "8.57.1",
+                "@typescript-eslint/utils": "8.57.1",
                 "debug": "^4.4.3",
                 "ts-api-utils": "^2.4.0"
             },
@@ -2687,9 +2683,9 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "8.57.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.57.0.tgz",
-            "integrity": "sha512-dTLI8PEXhjUC7B9Kre+u0XznO696BhXcTlOn0/6kf1fHaQW8+VjJAVHJ3eTI14ZapTxdkOmc80HblPQLaEeJdg==",
+            "version": "8.57.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.57.1.tgz",
+            "integrity": "sha512-S29BOBPJSFUiblEl6RzPPjJt6w25A6XsBqRVDt53tA/tlL8q7ceQNZHTjPeONt/3S7KRI4quk+yP9jK2WjBiPQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -2701,16 +2697,16 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "8.57.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.57.0.tgz",
-            "integrity": "sha512-m7faHcyVg0BT3VdYTlX8GdJEM7COexXxS6KqGopxdtkQRvBanK377QDHr4W/vIPAR+ah9+B/RclSW5ldVniO1Q==",
+            "version": "8.57.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.57.1.tgz",
+            "integrity": "sha512-ybe2hS9G6pXpqGtPli9Gx9quNV0TWLOmh58ADlmZe9DguLq0tiAKVjirSbtM1szG6+QH6rVXyU6GTLQbWnMY+g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/project-service": "8.57.0",
-                "@typescript-eslint/tsconfig-utils": "8.57.0",
-                "@typescript-eslint/types": "8.57.0",
-                "@typescript-eslint/visitor-keys": "8.57.0",
+                "@typescript-eslint/project-service": "8.57.1",
+                "@typescript-eslint/tsconfig-utils": "8.57.1",
+                "@typescript-eslint/types": "8.57.1",
+                "@typescript-eslint/visitor-keys": "8.57.1",
                 "debug": "^4.4.3",
                 "minimatch": "^10.2.2",
                 "semver": "^7.7.3",
@@ -2768,16 +2764,16 @@
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "8.57.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.57.0.tgz",
-            "integrity": "sha512-5iIHvpD3CZe06riAsbNxxreP+MuYgVUsV0n4bwLH//VJmgtt54sQeY2GszntJ4BjYCpMzrfVh2SBnUQTtys2lQ==",
+            "version": "8.57.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.57.1.tgz",
+            "integrity": "sha512-XUNSJ/lEVFttPMMoDVA2r2bwrl8/oPx8cURtczkSEswY5T3AeLmCy+EKWQNdL4u0MmAHOjcWrqJp2cdvgjn8dQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.9.1",
-                "@typescript-eslint/scope-manager": "8.57.0",
-                "@typescript-eslint/types": "8.57.0",
-                "@typescript-eslint/typescript-estree": "8.57.0"
+                "@typescript-eslint/scope-manager": "8.57.1",
+                "@typescript-eslint/types": "8.57.1",
+                "@typescript-eslint/typescript-estree": "8.57.1"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2792,13 +2788,13 @@
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "8.57.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.57.0.tgz",
-            "integrity": "sha512-zm6xx8UT/Xy2oSr2ZXD0pZo7Jx2XsCoID2IUh9YSTFRu7z+WdwYTRk6LhUftm1crwqbuoF6I8zAFeCMw0YjwDg==",
+            "version": "8.57.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.57.1.tgz",
+            "integrity": "sha512-YWnmJkXbofiz9KbnbbwuA2rpGkFPLbAIetcCNO6mJ8gdhdZ/v7WDXsoGFAJuM6ikUFKTlSQnjWnVO4ux+UzS6A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.57.0",
+                "@typescript-eslint/types": "8.57.1",
                 "eslint-visitor-keys": "^5.0.0"
             },
             "engines": {
@@ -4011,9 +4007,9 @@
             "license": "BSD-3-Clause"
         },
         "node_modules/fast-xml-builder": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.3.tgz",
-            "integrity": "sha512-1o60KoFw2+LWKQu3IdcfcFlGTW4dpqEWmjhYec6H82AYZU2TVBXep6tMl8Z1Y+wM+ZrzCwe3BZ9Vyd9N2rIvmg==",
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
+            "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
             "funding": [
                 {
                     "type": "github",
@@ -4026,9 +4022,9 @@
             }
         },
         "node_modules/fast-xml-parser": {
-            "version": "5.5.5",
-            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.5.tgz",
-            "integrity": "sha512-NLY+V5NNbdmiEszx9n14mZBseJTC50bRq1VHsaxOmR72JDuZt+5J1Co+dC/4JPnyq+WrIHNM69r0sqf7BMb3Mg==",
+            "version": "5.5.6",
+            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.6.tgz",
+            "integrity": "sha512-3+fdZyBRVg29n4rXP0joHthhcHdPUHaIC16cuyyd1iLsuaO6Vea36MPrxgAzbZna8lhvZeRL8Bc9GP56/J9xEw==",
             "funding": [
                 {
                     "type": "github",
@@ -4037,7 +4033,7 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "fast-xml-builder": "^1.1.3",
+                "fast-xml-builder": "^1.1.4",
                 "path-expression-matcher": "^1.1.3",
                 "strnum": "^2.1.2"
             },
@@ -4129,9 +4125,9 @@
             }
         },
         "node_modules/flatted": {
-            "version": "3.4.1",
-            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.1.tgz",
-            "integrity": "sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==",
+            "version": "3.4.2",
+            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+            "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
             "devOptional": true,
             "license": "ISC"
         },
@@ -4910,9 +4906,9 @@
             }
         },
         "node_modules/moment-timezone": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.6.0.tgz",
-            "integrity": "sha512-ldA5lRNm3iJCWZcBCab4pnNL3HSZYXVb/3TYr75/1WCTWYuTqYUb5f/S384pncYjJ88lbO8Z4uPDvmoluHJc8Q==",
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.6.1.tgz",
+            "integrity": "sha512-1B9lmAhB9D9/sHaPC1N7wLFEVUoFldxOpOO96lOD1PvJ43vCd0ozDPbu0FEL3++VvawOlDkq8YD373tJmP5JHw==",
             "license": "MIT",
             "dependencies": {
                 "moment": "^2.29.4"
@@ -5482,9 +5478,9 @@
             "license": "MIT"
         },
         "node_modules/sax": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/sax/-/sax-1.5.0.tgz",
-            "integrity": "sha512-21IYA3Q5cQf089Z6tgaUTr7lDAyzoTPx5HRtbhsME8Udispad8dC/+sziTNugOEx54ilvatQ9YCzl4KQLPcRHA==",
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+            "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
             "license": "BlueOak-1.0.0",
             "peer": true,
             "engines": {
@@ -5809,9 +5805,9 @@
             }
         },
         "node_modules/strnum": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.0.tgz",
-            "integrity": "sha512-Y7Bj8XyJxnPAORMZj/xltsfo55uOiyHcU2tnAVzHUnSJR/KsEX+9RoDeXEnsXtl/CX4fAcrt64gZ13aGaWPeBg==",
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.1.tgz",
+            "integrity": "sha512-BwRvNd5/QoAtyW1na1y1LsJGQNvRlkde6Q/ipqqEaivoMdV+B1OMOTVdwR+N/cwVUcIt9PYyHmV8HyexCZSupg==",
             "funding": [
                 {
                     "type": "github",
@@ -5893,9 +5889,9 @@
             }
         },
         "node_modules/ts-api-utils": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.4.0.tgz",
-            "integrity": "sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==",
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+            "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -5997,16 +5993,16 @@
             }
         },
         "node_modules/typescript-eslint": {
-            "version": "8.57.0",
-            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.57.0.tgz",
-            "integrity": "sha512-W8GcigEMEeB07xEZol8oJ26rigm3+bfPHxHvwbYUlu1fUDsGuQ7Hiskx5xGW/xM4USc9Ephe3jtv7ZYPQntHeA==",
+            "version": "8.57.1",
+            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.57.1.tgz",
+            "integrity": "sha512-fLvZWf+cAGw3tqMCYzGIU6yR8K+Y9NT2z23RwOjlNFF2HwSB3KhdEFI5lSBv8tNmFkkBShSjsCjzx1vahZfISA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/eslint-plugin": "8.57.0",
-                "@typescript-eslint/parser": "8.57.0",
-                "@typescript-eslint/typescript-estree": "8.57.0",
-                "@typescript-eslint/utils": "8.57.0"
+                "@typescript-eslint/eslint-plugin": "8.57.1",
+                "@typescript-eslint/parser": "8.57.1",
+                "@typescript-eslint/typescript-estree": "8.57.1",
+                "@typescript-eslint/utils": "8.57.1"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -6021,9 +6017,9 @@
             }
         },
         "node_modules/undici": {
-            "version": "7.24.3",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.3.tgz",
-            "integrity": "sha512-eJdUmK/Wrx2d+mnWWmwwLRyA7OQCkLap60sk3dOK4ViZR7DKwwptwuIvFBg2HaiP9ESaEdhtpSymQPvytpmkCA==",
+            "version": "7.24.4",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.4.tgz",
+            "integrity": "sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w==",
             "license": "MIT",
             "engines": {
                 "node": ">=20.18.1"

--- a/task.ts
+++ b/task.ts
@@ -632,6 +632,11 @@ export default class Task extends ETL {
                     continue;
                 }
 
+                if (alert.info.expires && new Date(alert.info.expires) < new Date()) {
+                    console.log(`Skipping expired alert ${alert.identifier} (expired: ${alert.info.expires})`);
+                    continue;
+                }
+
                 // Create feature from CAP alert
                 let geometry: SupportedGeometry | null = null;
                 


### PR DESCRIPTION
### Problem

CAP alerts were remaining visible on the map past their `expires` time. When an alert's `expires` timestamp was already in the past, CloudTAK's `connection-layer-cot.ts` still accepted and upserted the feature (the `cot.is_stale` filter keeps already-stale CoTs, not discards them). On each subsequent ETL run the feature was re-upserted, continuously refreshing it in the database and preventing natural expiry.

### Fix

Skip submission of any CAP alert whose `expires` field is already in the past. This prevents expired alerts from being re-upserted into CloudTAK on each ETL run.

### Dependencies

Updated all dependencies to latest versions:

| Package | Before | After |
|---|---|---|
| `@tak-ps/etl` | 9.24.0 | 10.4.0 |
| `fast-xml-parser` | 4.5.3 | 5.5.6 |
| `typescript` | 5.8.3 | 5.9.3 |
| `eslint` | 9.32.0 | 9.39.4 |
| `typescript-eslint` | 8.38.0 | 8.57.1 |
| `@sinclair/typebox` | 0.34.38 | 0.34.48 |
